### PR TITLE
add support for global region

### DIFF
--- a/gcp_audit_rules/gcp_unused_regions.py
+++ b/gcp_audit_rules/gcp_unused_regions.py
@@ -7,6 +7,7 @@ APPROVED_ACTIVE_REGIONS = {
     # 'northamerica',
     # 'southamerica',
     "us",
+    "global",
 }
 
 

--- a/gcp_audit_rules/gcp_unused_regions.yml
+++ b/gcp_audit_rules/gcp_unused_regions.yml
@@ -273,3 +273,26 @@ Tests:
         "severity": "ERROR",
         "timestamp": "2021-10-19 16:09:26.013200000"
       }
+  -
+    Name: "DNS Change in global region"
+    ExpectedResult: false
+    Log:
+      {
+        "logName": "projects/someproject/logs/cloudaudit.googleapis.com%2Factivity",
+        "protoPayload": {
+          "at_sign_type": "type.googleapis.com/google.cloud.audit.AuditLog",
+          "methodName": "dns.changes.create",
+          "resourceName": "managedZones/somezone",
+          "serviceName": "dns.googleapis.com",
+          "status": {}
+        },
+        "resource": {
+          "labels": {
+            "location": "global",
+            "project_id": "someproject",
+            "zone_name": "somezone"
+          },
+          "type": "dns_managed_zone"
+        },
+        "severity": "NOTICE",
+      }


### PR DESCRIPTION
### Background

suppress alerts related to use of the `global` region

### Changes

- add test
- add global to gcp allowed regions

### Testing

```
$ pipenv run panther_analysis_tool test --filter RuleID=GCP.UnusedRegions
[INFO]: Testing analysis items in .

GCP.UnusedRegions
        [PASS] GCE Instance Terminated
                [PASS] [rule] false
        [PASS] GCE Create Instance in SouthAmerica
                [PASS] [rule] true
                [PASS] [title] GCP resource(s) created in unused region/zone in project western-verve-123456
                [PASS] [dedup] GCP resource(s) created in unused region/zone in project western-verve-123456
        [PASS] Create GCS in Asia
                [PASS] [rule] true
                [PASS] [title] GCP resource(s) created in unused region/zone in project western-verve-123456
                [PASS] [dedup] GCP resource(s) created in unused region/zone in project western-verve-123456
        [PASS] BigQuery access log (does not have standard attribute: resource.labels.location)
                [PASS] [rule] false
        [PASS] DNS Change in global region
                [PASS] [rule] false

--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 1
        Failed: 0
        Invalid: 0
```